### PR TITLE
feat: C Code Coverage mit gcov/lcov für SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Shellcheck
         run: |
           shellcheck report.sh build_adoc.sh bausteinsicht-container.sh bausteinsicht.sh \
+            c_coverage.sh \
             || true  # Warnings are non-blocking
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/).
 ### Added
 
 - `docs/sonarcloud-trend.md`: Dokumentation für SonarCloud Quality Metrics Trend-Tracking — erklärt automatische Snapshots, vorausgesetzte Einrichtung (Automatic Analysis deaktivieren) und Branch-Vergleich bei PRs (#2)
+- `c_coverage.sh`: Shell-Helfer für C Code Coverage mit gcov/lcov — erzeugt `.info`-Datei für `sonar.c.lcov.reportPaths`, unterstützt mehrere Filter-Muster für System-Headers (#10)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ CI/CD Tooling für das [BeagleBone Black](https://github.com/paulefl/beaglebone_
 | `req_tracing_summary.py` | Erzeugt Requirements-Traceability-Zusammenfassung |
 | `junit_to_sonar_generic.py` | Konvertiert JUnit XML → Sonar Generic Test Format |
 | `shellcheck_to_sarif.py` | Konvertiert shellcheck JSON → SARIF |
+| `c_coverage.sh` | C Code Coverage mit gcov/lcov → `.info`-Datei für SonarCloud |
 | `bausteinsicht` | Bausteinsicht-Diagramm-Generator (Binary) |
 
 ## Tests ausführen

--- a/c_coverage.sh
+++ b/c_coverage.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# c_coverage.sh — C Code Coverage mit gcov/lcov für SonarCloud
+#
+# Erzeugt eine lcov .info-Datei aus gcov-Daten (*.gcda/*.gcno) eines Build-Verzeichnisses.
+# SonarCloud liest sie via sonar.c.lcov.reportPaths ein.
+#
+# Verwendung:
+#   c_coverage.sh <source-dir> <output.info> [<filter-pattern>...]
+#
+# Argumente:
+#   source-dir      Verzeichnis mit den *.gcda/*.gcno Dateien (z.B. c-lib/)
+#   output.info     Zieldatei für den lcov-Report (z.B. reports/c-coverage.info)
+#   filter-pattern  Optionale Exclude-Muster (Default: '/usr/*')
+#                   Mehrere Muster als separate Argumente möglich.
+#
+# Beispiel:
+#   c_coverage.sh c-lib/ reports/c-coverage.info '/usr/*' '*/test/*'
+#
+# Voraussetzungen: gcc (mit -fprofile-arcs -ftest-coverage gebaut), lcov
+
+set -euo pipefail
+
+# ── Argument-Validierung ──────────────────────────────────────────────────────
+
+usage() {
+    echo "Verwendung: $0 <source-dir> <output.info> [<filter-pattern>...]" >&2
+    echo "" >&2
+    echo "  source-dir      Verzeichnis mit *.gcda/*.gcno Dateien" >&2
+    echo "  output.info     Zieldatei für lcov-Report" >&2
+    echo "  filter-pattern  Exclude-Muster (Standard: '/usr/*')" >&2
+    exit 1
+}
+
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+SOURCE_DIR="$1"
+OUTPUT_FILE="$2"
+shift 2
+
+# Standard-Filter wenn keine angegeben
+if [ $# -eq 0 ]; then
+    set -- '/usr/*'
+fi
+
+# ── Voraussetzungen prüfen ────────────────────────────────────────────────────
+
+if ! command -v lcov >/dev/null 2>&1; then
+    echo "Fehler: lcov nicht gefunden. Installation: apt-get install lcov" >&2
+    exit 2
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Fehler: Quell-Verzeichnis '$SOURCE_DIR' nicht gefunden." >&2
+    exit 3
+fi
+
+# ── Coverage erfassen ─────────────────────────────────────────────────────────
+
+OUTPUT_DIR="$(dirname "$OUTPUT_FILE")"
+if [ -n "$OUTPUT_DIR" ] && [ "$OUTPUT_DIR" != "." ]; then
+    mkdir -p "$OUTPUT_DIR"
+fi
+
+echo "[c_coverage] Erfasse Coverage aus: $SOURCE_DIR"
+lcov --capture \
+     --directory "$SOURCE_DIR" \
+     --output-file "$OUTPUT_FILE" \
+     --rc lcov_branch_coverage=1 \
+     --quiet
+
+# ── Filter anwenden ───────────────────────────────────────────────────────────
+
+for pattern in "$@"; do
+    echo "[c_coverage] Filtere aus: $pattern"
+    lcov --remove "$OUTPUT_FILE" \
+         "$pattern" \
+         --output-file "$OUTPUT_FILE" \
+         --rc lcov_branch_coverage=1 \
+         --quiet
+done
+
+# ── Zusammenfassung ───────────────────────────────────────────────────────────
+
+echo "[c_coverage] Report geschrieben: $OUTPUT_FILE"
+lcov --summary "$OUTPUT_FILE" --rc lcov_branch_coverage=1

--- a/tests/test_c_coverage.py
+++ b/tests/test_c_coverage.py
@@ -1,0 +1,45 @@
+"""Tests für c_coverage.sh (TOOL-COV-001)"""
+import os
+import subprocess
+import stat
+
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "c_coverage.sh")
+
+
+def test_script_exists():
+    """c_coverage.sh ist vorhanden."""
+    assert os.path.isfile(SCRIPT)
+
+
+def test_script_is_executable():
+    """c_coverage.sh hat ausführbare Rechte."""
+    mode = os.stat(SCRIPT).st_mode
+    assert mode & stat.S_IXUSR, "Script ist nicht executable (u+x)"
+
+
+def test_no_args_prints_usage():
+    """Ohne Argumente: Exit 1 und Verwendungshinweis."""
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 1
+    assert "Verwendung" in result.stderr
+
+
+def test_missing_source_dir_exits_nonzero(tmp_path):
+    """Nicht existierendes Quell-Verzeichnis → Exit != 0."""
+    result = subprocess.run(
+        ["bash", SCRIPT, str(tmp_path / "nonexistent"), str(tmp_path / "out.info")],
+        capture_output=True, text=True
+    )
+    assert result.returncode != 0
+
+
+def test_bash_syntax():
+    """Bash-Syntax des Scripts ist fehlerfrei (bash -n)."""
+    result = subprocess.run(
+        ["bash", "-n", SCRIPT],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"Syntax-Fehler: {result.stderr}"


### PR DESCRIPTION
## Summary

- `c_coverage.sh`: Shell-Helfer der gcov/lcov-Workflow kapselt — `lcov --capture`, System-Header-Filter, Summary-Ausgabe → `.info`-Datei für `sonar.c.lcov.reportPaths`
- `tests/test_c_coverage.py`: 5 Tests (Existenz, Executable-Bit, Fehlerverhalten, Bash-Syntax)
- CI: `c_coverage.sh` in shellcheck-Job aufgenommen
- README + CHANGELOG aktualisiert

## Test plan

- [ ] `pytest tests/test_c_coverage.py` — 5 Tests grün
- [ ] `c_coverage.sh` ohne Argumente gibt Verwendungshinweis und Exit 1
- [ ] `c_coverage.sh` mit nicht-existentem Verzeichnis gibt Fehler und Exit != 0
- [ ] shellcheck prüft `c_coverage.sh` ohne Fehler

Closes #10