### PR TITLE
feat: Composite Action c-coverage für GitHub Actions

### DIFF
--- a/.github/actions/c-coverage/action.yml
+++ b/.github/actions/c-coverage/action.yml
@@ -1,0 +1,56 @@
+name: 'C Code Coverage'
+description: >
+  Erzeugt eine lcov .info-Datei aus gcov-Daten für SonarCloud
+  (sonar.c.lcov.reportPaths). Setzt voraus, dass der C-Code mit
+  -fprofile-arcs -ftest-coverage gebaut und die Tests ausgeführt wurden.
+
+inputs:
+  source-dir:
+    description: 'Verzeichnis mit *.gcda/*.gcno Dateien (z.B. c-lib/)'
+    required: true
+    default: 'c-lib/'
+  output-file:
+    description: 'Zieldatei für lcov-Report (z.B. reports/c-coverage.info)'
+    required: true
+    default: 'reports/c-coverage.info'
+  filter-patterns:
+    description: >
+      Leerzeichen-getrennte Exclude-Muster für lcov --remove.
+      Standard: '/usr/*'
+    required: false
+    default: '/usr/*'
+  upload-artifact:
+    description: 'Coverage-Datei als GitHub-Artefakt hochladen (true/false)'
+    required: false
+    default: 'true'
+  artifact-name:
+    description: 'Name des GitHub-Artefakts'
+    required: false
+    default: 'c-coverage'
+
+outputs:
+  coverage-file:
+    description: 'Pfad zur erzeugten .info-Datei'
+    value: ${{ inputs.output-file }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install lcov
+      shell: bash
+      run: sudo apt-get install -y --no-install-recommends lcov
+
+    - name: Generate C coverage report
+      shell: bash
+      run: |
+        "${{ github.action_path }}/../../../c_coverage.sh" \
+          "${{ inputs.source-dir }}" \
+          "${{ inputs.output-file }}" \
+          ${{ inputs.filter-patterns }}
+
+    - name: Upload coverage artifact
+      if: inputs.upload-artifact == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.output-file }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/).
 
 - `docs/sonarcloud-trend.md`: Dokumentation für SonarCloud Quality Metrics Trend-Tracking — erklärt automatische Snapshots, vorausgesetzte Einrichtung (Automatic Analysis deaktivieren) und Branch-Vergleich bei PRs (#2)
 - `c_coverage.sh`: Shell-Helfer für C Code Coverage mit gcov/lcov — erzeugt `.info`-Datei für `sonar.c.lcov.reportPaths`, unterstützt mehrere Filter-Muster für System-Headers (#10)
+- `.github/actions/c-coverage`: GitHub Composite Action für C Coverage — kapselt lcov-Installation, Coverage-Generierung und Artefakt-Upload; verwendbar via `uses: paulefl/beaglebone-tooling/.github/actions/c-coverage@main`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ pip install pytest
 pytest tests/ -v
 ```
 
+## GitHub Actions (Composite Actions)
+
+### c-coverage — C Code Coverage mit gcov/lcov
+
+```yaml
+- name: Build c-lib with coverage
+  run: make -C c-lib coverage CC=gcc
+
+- name: Run C tests
+  run: make -C c-lib test
+
+- uses: paulefl/beaglebone-tooling/.github/actions/c-coverage@main
+  with:
+    source-dir: c-lib/
+    output-file: reports/c-coverage.info
+    filter-patterns: '/usr/*'   # optional, das ist der Default
+```
+
+Danach in `sonar-project.properties`:
+```properties
+sonar.c.lcov.reportPaths=reports/c-coverage.info
+```
+
 ## Verwendung im BeagleBone-Projekt
 
 Das Tooling wird via GitHub Releases eingebunden:


### PR DESCRIPTION
## Summary

- `.github/actions/c-coverage/action.yml`: GitHub Composite Action die lcov-Installation, Coverage-Generierung und Artefakt-Upload kapselt
- Verwendet intern `c_coverage.sh` — kein doppelter Code
- README: Nutzungsbeispiel mit vollständigem CI-Snippet + sonar-project.properties
- CHANGELOG aktualisiert

## Verwendung in beaglebone_black

```yaml
- name: Build c-lib with coverage
  run: make -C c-lib coverage CC=gcc

- name: Run C tests
  run: make -C c-lib test

- uses: paulefl/beaglebone-tooling/.github/actions/c-coverage@main
  with:
    source-dir: c-lib/
    output-file: reports/c-coverage.info
```

## Inputs

| Input | Default | Beschreibung |
|-------|---------|-------------|
| `source-dir` | `c-lib/` | Verzeichnis mit *.gcda/*.gcno |
| `output-file` | `reports/c-coverage.info` | Zieldatei |
| `filter-patterns` | `/usr/*` | lcov --remove Muster |
| `upload-artifact` | `true` | Artefakt hochladen |
| `artifact-name` | `c-coverage` | Artefakt-Name |