### PR TITLE
feat(#4): StrictDoc → SARIF für Requirements Coverage Gaps

### DIFF
--- a/.github/actions/sonarcloud/action.yml
+++ b/.github/actions/sonarcloud/action.yml
@@ -52,6 +52,11 @@ inputs:
     required: false
     default: shell-sarif
 
+  requirements-sarif-artifact:
+    description: Artifact name for Requirements Coverage SARIF (empty = skip). (#4)
+    required: false
+    default: requirements-sarif
+
   # Future SARIF artifacts — add inputs here as issues are implemented:
   # go-sarif-artifact:      feat: SARIF Report für Go — golangci-lint (#8)
   # python-sarif-artifact:  feat: SARIF Report für Python — bandit (#5)
@@ -101,6 +106,14 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.shell-sarif-artifact }}
+        path: reports/
+      continue-on-error: true
+
+    - name: Download Requirements Coverage SARIF
+      if: inputs.requirements-sarif-artifact != ''
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.requirements-sarif-artifact }}
         path: reports/
       continue-on-error: true
 

--- a/.github/actions/strictdoc/action.yml
+++ b/.github/actions/strictdoc/action.yml
@@ -3,9 +3,11 @@ description: >
   Full StrictDoc pipeline: setup Python, install StrictDoc + test deps,
   run pytest for test-traceability, install Chromium if needed,
   run make req-tracing, write traceability summary via req_tracing_summary.py,
-  and upload HTML/PDF/Excel/ReqIF artifacts.
+  convert requirements coverage gaps to SARIF via strictdoc_to_sarif.py,
+  upload SARIF to GitHub Code Scanning, and upload HTML/PDF/Excel/ReqIF artifacts.
   Requires actions/checkout to have run in the calling job.
   Scripts are resolved via GITHUB_ACTION_PATH — no download-tooling needed.
+  Job must declare security-events: write when upload-sarif is true.
 
 inputs:
   python-version:
@@ -42,6 +44,21 @@ inputs:
     description: Whether to upload HTML/PDF/Excel/ReqIF artifacts ('true'/'false').
     required: false
     default: 'true'
+
+  sdoc-glob:
+    description: Glob pattern to find .sdoc requirement files.
+    required: false
+    default: docs/requirements/**/*.sdoc
+
+  upload-sarif:
+    description: Convert requirements gaps to SARIF and upload to GitHub Code Scanning ('true'/'false'). Requires security-events:write in the calling job.
+    required: false
+    default: 'true'
+
+  sarif-artifact:
+    description: Artifact name for the requirements SARIF (empty = no upload).
+    required: false
+    default: requirements-sarif
 
 runs:
   using: composite
@@ -87,6 +104,30 @@ runs:
       if: always()
       shell: bash
       run: python3 "$GITHUB_ACTION_PATH/../../../req_tracing_summary.py"
+
+    - name: Requirements Coverage → SARIF
+      if: always()
+      shell: bash
+      run: |
+        python3 "$GITHUB_ACTION_PATH/../../../strictdoc_to_sarif.py" \
+          --sdoc-glob "${{ inputs.sdoc-glob }}" \
+          --output reports/requirements-coverage.sarif
+
+    - name: Upload Requirements SARIF to GitHub Code Scanning
+      if: inputs.upload-sarif == 'true'
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: reports/requirements-coverage.sarif
+        category: requirements-coverage
+
+    - name: Upload Requirements SARIF Artifact
+      if: inputs.sarif-artifact != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.sarif-artifact }}
+        path: reports/requirements-coverage.sarif
+        retention-days: ${{ inputs.retention-days }}
 
     - name: Upload StrictDoc HTML
       if: inputs.upload-artifacts == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,9 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/).
 
 - `go-test`: JUnit → SARIF Konvertierung via `junit2sarif` + Upload zu GitHub Code Scanning (`upload-sarif` Input, default true; erfordert `security-events: write`)
 - `python-test`: JUnit → SARIF Konvertierung via `junit2sarif` + Upload zu GitHub Code Scanning (`upload-sarif` Input, default true; erfordert `security-events: write`)
+
+### Added (Issue #4)
+
+- `strictdoc_to_sarif.py`: Konvertiert StrictDoc-Anforderungen ohne `TYPE: File` Relations in SARIF 2.1.0 — erscheinen als Code Smells in SonarCloud und GitHub Code Scanning
+- `strictdoc`: SARIF-Generierung via `strictdoc_to_sarif.py` + Upload zu GitHub Code Scanning + Artifact `requirements-sarif`; neue Inputs: `sdoc-glob`, `upload-sarif`, `sarif-artifact`; erfordert `security-events: write`
+- `sonarcloud`: lädt `requirements-sarif` Artifact herunter (Issue #4); Placeholder für künftige SARIF-Issues (#5–#8, #9) bleibt erhalten

--- a/strictdoc_to_sarif.py
+++ b/strictdoc_to_sarif.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Convert StrictDoc requirements coverage gaps to SARIF 2.1.0.
+
+Requirements without any TYPE: File relations are reported as SARIF findings
+so they appear as Code Smells in SonarCloud / GitHub Code Scanning.
+
+Usage:
+    python3 strictdoc_to_sarif.py [--sdoc-glob GLOB] [--output FILE]
+
+Defaults:
+    --sdoc-glob  docs/requirements/**/*.sdoc
+    --output     reports/requirements-coverage.sarif
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+RULE_ID = "REQ-UNCOVERED"
+REQUIREMENT_TYPES = re.compile(
+    r"^\[(?:REQUIREMENT|SW_REQUIREMENT|SYS_REQUIREMENT|GUI_REQUIREMENT"
+    r"|HW_DRV_REQUIREMENT|HW_REQUIREMENT|SECTION|/SECTION|DOCUMENT|TEXT)\]",
+    re.MULTILINE,
+)
+
+
+def parse_sdoc_file(sdoc_path: str) -> list[dict]:
+    """Parse a .sdoc file and return list of requirement dicts with line numbers."""
+    content = open(sdoc_path, encoding="utf-8").read()
+    lines = content.splitlines()
+
+    # Build a line-number index: char offset → line number
+    offsets: list[int] = [0]
+    for line in lines:
+        offsets.append(offsets[-1] + len(line) + 1)
+
+    def char_to_line(pos: int) -> int:
+        lo, hi = 0, len(offsets) - 1
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if offsets[mid] <= pos < offsets[mid + 1]:
+                return mid + 1
+            elif pos < offsets[mid]:
+                hi = mid
+            else:
+                lo = mid + 1
+        return lo + 1
+
+    # Split on any known block header
+    req_types = re.compile(
+        r"\[(?:REQUIREMENT|SW_REQUIREMENT|SYS_REQUIREMENT|GUI_REQUIREMENT"
+        r"|HW_DRV_REQUIREMENT|HW_REQUIREMENT)\]"
+    )
+
+    reqs = []
+    for m in req_types.finditer(content):
+        start = m.start()
+        # Find end: next block header or end of file
+        next_block = REQUIREMENT_TYPES.search(content, m.end())
+        block = content[m.end(): next_block.start() if next_block else len(content)]
+        line_no = char_to_line(start)
+
+        uid_m = re.search(r"^UID:\s*(.+)$", block, re.MULTILINE)
+        title_m = re.search(r"^TITLE:\s*(.+)$", block, re.MULTILINE)
+        status_m = re.search(r"^STATUS:\s*(.+)$", block, re.MULTILINE)
+
+        if not uid_m:
+            continue
+
+        uid = uid_m.group(1).strip()
+        title = title_m.group(1).strip() if title_m else uid
+        status = status_m.group(1).strip() if status_m else "Active"
+
+        # Collect all RELATIONS blocks: TYPE + VALUE pairs
+        has_file_relation = bool(
+            re.search(r"TYPE:\s*File", block, re.MULTILINE)
+        )
+
+        reqs.append({
+            "uid": uid,
+            "title": title,
+            "status": status,
+            "has_file": has_file_relation,
+            "line": line_no,
+            "file": sdoc_path,
+        })
+
+    return reqs
+
+
+def to_sarif(gaps: list[dict], sdoc_glob: str) -> dict:
+    """Convert a list of uncovered requirements to a SARIF document."""
+    results = []
+    for req in gaps:
+        uri = req["file"].replace("\\", "/")
+        # Make path relative to workspace root if possible
+        try:
+            uri = str(Path(uri).relative_to(Path.cwd())).replace("\\", "/")
+        except ValueError:
+            pass
+
+        results.append({
+            "ruleId": RULE_ID,
+            "level": "warning",
+            "message": {
+                "text": (
+                    f"Requirement {req['uid']} '{req['title']}' has no File relations. "
+                    f"Link it to at least one implementation or test file via "
+                    f"RELATIONS / TYPE: File."
+                )
+            },
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": uri,
+                        "uriBaseId": "%SRCROOT%",
+                    },
+                    "region": {"startLine": req["line"]},
+                }
+            }],
+            "properties": {
+                "uid": req["uid"],
+                "status": req["status"],
+            },
+        })
+
+    return {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "StrictDoc Requirements Coverage",
+                    "version": "1.0.0",
+                    "informationUri": "https://github.com/paulefl/beaglebone-tooling",
+                    "rules": [{
+                        "id": RULE_ID,
+                        "name": "UncoveredRequirement",
+                        "shortDescription": {"text": "Requirement without File relation"},
+                        "fullDescription": {
+                            "text": (
+                                "A requirement has no TYPE: File relations. "
+                                "Every requirement should be linked to at least one "
+                                "implementation or test file to ensure traceability."
+                            )
+                        },
+                        "defaultConfiguration": {"level": "warning"},
+                        "properties": {"tags": ["requirements", "traceability"]},
+                    }],
+                }
+            },
+            "results": results,
+        }],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sdoc-glob",
+        default="docs/requirements/**/*.sdoc",
+        help="Glob pattern for .sdoc files (default: docs/requirements/**/*.sdoc)",
+    )
+    parser.add_argument(
+        "--output",
+        default="reports/requirements-coverage.sarif",
+        help="Output SARIF file path (default: reports/requirements-coverage.sarif)",
+    )
+    args = parser.parse_args()
+
+    sdoc_files = glob.glob(args.sdoc_glob, recursive=True)
+    if not sdoc_files:
+        print(f"No .sdoc files found matching: {args.sdoc_glob}", file=sys.stderr)
+        # Write empty SARIF so downstream steps don't fail
+        sarif = to_sarif([], args.sdoc_glob)
+        os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(sarif, f, indent=2)
+        print(f"Written: {args.output} (0 findings — no .sdoc files found)")
+        return
+
+    all_reqs: list[dict] = []
+    for path in sorted(sdoc_files):
+        all_reqs.extend(parse_sdoc_file(path))
+
+    gaps = [r for r in all_reqs if not r["has_file"]]
+
+    sarif = to_sarif(gaps, args.sdoc_glob)
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(sarif, f, indent=2, ensure_ascii=False)
+
+    total = len(all_reqs)
+    print(
+        f"Written: {args.output} "
+        f"({len(gaps)} uncovered / {total} total requirements)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `strictdoc_to_sarif.py`: parst `.sdoc`-Dateien, findet Anforderungen ohne `TYPE: File`-Relations, erzeugt SARIF 2.1.0 mit zeilengenauen Locations
- `strictdoc` action: neues SARIF-Generation-Step + GitHub Code Scanning Upload + `requirements-sarif` Artifact; neue Inputs: `sdoc-glob`, `upload-sarif`, `sarif-artifact`
- `sonarcloud` action: lädt `requirements-sarif` herunter; Placeholder für #5–#8, #9 bleibt

## Änderungen in beaglebone_black

- `strictdoc` Job: `security-events: write` Permission
- `sonarcloud` Job: `needs` um `strictdoc` erweitert (damit SARIF-Artifact vorhanden ist)
- Version Bump auf v1.1.11

## Test plan

- [ ] CI grün
- [ ] `reports/requirements-coverage.sarif` wird als Artifact hochgeladen
- [ ] 0 Findings bei vollständig gedeckten Requirements (beaglebone_black hat 18/18 gedeckt)

Closes #4