### PR TITLE
feat(#5): python-security action — bandit SARIF

### DIFF
--- a/.github/actions/python-security/action.yml
+++ b/.github/actions/python-security/action.yml
@@ -1,0 +1,81 @@
+name: Python Security Scan
+description: >
+  Runs bandit (OWASP Python Security Scanner) and produces a SARIF report
+  for GitHub Code Scanning and SonarCloud.
+  Requires actions/checkout to have run in the calling job.
+  Job must declare security-events: write when upload-sarif is true.
+
+inputs:
+  python-version:
+    description: Python version.
+    required: false
+    default: '3.12'
+
+  scan-targets:
+    description: Space-separated directories/files to scan with bandit.
+    required: false
+    default: tests/
+
+  bandit-args:
+    description: Additional bandit CLI arguments (e.g. '-ll' for high-severity only).
+    required: false
+    default: ''
+
+  sarif-output:
+    description: Path for the SARIF output file.
+    required: false
+    default: reports/python-security.sarif
+
+  artifact-name:
+    description: Artifact name for the SARIF report (empty = no upload).
+    required: false
+    default: python-sarif
+
+  retention-days:
+    description: Artifact retention in days.
+    required: false
+    default: '30'
+
+  upload-sarif:
+    description: Upload SARIF to GitHub Code Scanning ('true'/'false'). Requires security-events:write.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install bandit
+      shell: bash
+      run: pip install bandit --quiet
+
+    - name: Python Security Scan (bandit → SARIF)
+      shell: bash
+      run: |
+        mkdir -p "$(dirname "${{ inputs.sarif-output }}")"
+        bandit -r ${{ inputs.scan-targets }} \
+          --format sarif \
+          --output ${{ inputs.sarif-output }} \
+          ${{ inputs.bandit-args }} \
+          --exit-zero
+        echo "Findings: $(python3 -c "import json; d=json.load(open('${{ inputs.sarif-output }}')); print(len(d['runs'][0]['results']))" 2>/dev/null || echo '?')"
+
+    - name: Upload Python Security SARIF to GitHub Code Scanning
+      if: inputs.upload-sarif == 'true'
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-output }}
+        category: python-security
+
+    - name: Upload Python Security SARIF Artifact
+      if: inputs.artifact-name != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.sarif-output }}
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/sonarcloud/action.yml
+++ b/.github/actions/sonarcloud/action.yml
@@ -59,7 +59,11 @@ inputs:
 
   # Future SARIF artifacts — add inputs here as issues are implemented:
   # go-sarif-artifact:      feat: SARIF Report für Go — golangci-lint (#8)
-  # python-sarif-artifact:  feat: SARIF Report für Python — bandit (#5)
+  python-sarif-artifact:
+    description: Artifact name for Python Security SARIF / bandit (empty = skip). (#5)
+    required: false
+    default: python-sarif
+
   # c-sarif-artifact:       feat: SARIF Report für C — clang-tidy (#7)
   # rust-sarif-artifact:    feat: SARIF Report für Rust — clippy (#6)
   # rust-coverage-artifact: feat: Rust Coverage — cargo-llvm-cov (#9)
@@ -117,7 +121,15 @@ runs:
         path: reports/
       continue-on-error: true
 
-    # Future downloads go here as issues #5–#8, #9 are implemented.
+    - name: Download Python Security SARIF
+      if: inputs.python-sarif-artifact != ''
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.python-sarif-artifact }}
+        path: reports/
+      continue-on-error: true
+
+    # Future downloads go here as issues #6–#8, #9 are implemented.
 
     # ── SonarCloud Scan ─────────────────────────────────────────────────────
     - name: SonarCloud Scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,8 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/).
 - `strictdoc_to_sarif.py`: Konvertiert StrictDoc-Anforderungen ohne `TYPE: File` Relations in SARIF 2.1.0 — erscheinen als Code Smells in SonarCloud und GitHub Code Scanning
 - `strictdoc`: SARIF-Generierung via `strictdoc_to_sarif.py` + Upload zu GitHub Code Scanning + Artifact `requirements-sarif`; neue Inputs: `sdoc-glob`, `upload-sarif`, `sarif-artifact`; erfordert `security-events: write`
 - `sonarcloud`: lädt `requirements-sarif` Artifact herunter (Issue #4); Placeholder für künftige SARIF-Issues (#5–#8, #9) bleibt erhalten
+
+### Added (Issue #5)
+
+- `.github/actions/python-security`: GitHub Composite Action für Python Security Scanning — bandit OWASP Scanner mit nativem SARIF-Output, Upload zu GitHub Code Scanning + SonarCloud via `python-sarif` Artifact; Inputs: `scan-targets`, `bandit-args`, `upload-sarif`, `artifact-name`
+- `sonarcloud`: lädt `python-sarif` Artifact herunter (Issue #5)


### PR DESCRIPTION
## Summary

- Neues `.github/actions/python-security`: bandit OWASP Security Scanner mit nativem `--format sarif` Output
- Upload zu GitHub Code Scanning (`continue-on-error`) + `python-sarif` Artifact für SonarCloud
- `sonarcloud` action: `python-sarif-artifact` Input + Download-Step

## Änderungen in beaglebone_black

- Neuer Job `security-python` (`checkout + python-security@v1.1.12`, `security-events: write`)
- `sonarcloud` Job: `needs` um `security-python` erweitert
- Version Bump auf v1.1.12

## Test plan

- [ ] CI grün
- [ ] `python-sarif` Artifact wird hochgeladen
- [ ] bandit findet 0 oder mehr Findings (kein CI-Blocker via `--exit-zero`)

Closes #5